### PR TITLE
Updated f string in python script, removed && env, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ You'll want to update `update_env.sh` to have an echo statement with "TEAM1_FLAG
 * --flags_per_team
   * [OPTIONAL] Flags per team. Default 4.')
 * --env_updater_script
-  * [OPTIONAL] Path to a script to update environment variables with flags.
+  * [OPTIONAL] Path to a script to that will echo the flags with one flag per line in the format of TEAM1_FLAG1=RTA{123-123-123}.
 
 

--- a/ctf_automate_flagsend.py
+++ b/ctf_automate_flagsend.py
@@ -74,7 +74,7 @@ def main():
     while True:
         try:
             #Run the updater script and capture the output
-            output = subprocess.check_output(f"bash {UPDATER_SCRIPT} && env", shell=True, text=True)
+            output = subprocess.check_output(f"bash {UPDATER_SCRIPT}", shell=True, text=True)
 
             # Parse the output to update the environment variables
             env_updates = dict(line.split("=", 1) for line in output.splitlines() if 'FLAG' in line)
@@ -86,7 +86,7 @@ def main():
 
         for team in teams:
             team.send_flags()
-        print(f"{time.strftime("%H:%M:%S", time.localtime())}: Sleeping for {SLEEP_INTERVAL} seconds.")
+        print(f"{time.strftime('%H:%M:%S', time.localtime())}: Sleeping for {SLEEP_INTERVAL} seconds.")
         time.sleep(SLEEP_INTERVAL)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Double quotations in f string caused a syntax error. Removed “&& env” in subprocess.check_output for the env_updater_script. The python script currently runs the script and than looks in the output for FLAG and then uses the = to split into a dictionary which is used to update the environmental variables. There is no need for the env_update.sh script to export anything into the environmental variables. It just needs to echo the flags in the format of TEAM1_FLAG1=RTA{123-123-132}. To simplify the script I removed && env from the subprocess.check_output and updated the readme to indicate that the script should just echo the flag in the correct format. This approach is cleaner and also the && env does not always works because when the bash script runs it is normal run in a new shell with a new environment and the && env will not catch the exported flags as it is run in the original shell.